### PR TITLE
feat: use meeting context for websocket and heartbeat

### DIFF
--- a/frontend/src/MeetingContext.js
+++ b/frontend/src/MeetingContext.js
@@ -1,0 +1,82 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import axios from "axios";
+
+const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || import.meta.env.REACT_APP_BACKEND_URL;
+const API = `${BACKEND_URL}/api`;
+
+const MeetingContext = createContext();
+
+export const MeetingProvider = ({ children }) => {
+  const [meeting, setMeeting] = useState(null);
+  const [participant, setParticipant] = useState(null);
+  const [ws, setWs] = useState(null);
+  const [meetingClosed, setMeetingClosed] = useState(false);
+  const [lastHeartbeat, setLastHeartbeat] = useState(Date.now());
+
+  const connectWebSocket = (meetingId) => {
+    const wsUrl = `${BACKEND_URL.replace("https://", "wss://").replace("http://", "ws://")}/ws/meetings/${meetingId}`;
+    const websocket = new WebSocket(wsUrl);
+
+    websocket.onopen = () => {
+      console.log("WebSocket connected");
+      setWs(websocket);
+    };
+
+    websocket.onmessage = (event) => {
+      const data = JSON.parse(event.data);
+      console.log("WebSocket message:", data);
+    };
+
+    websocket.onerror = (error) => {
+      console.error("WebSocket error:", error);
+    };
+
+    websocket.onclose = () => {
+      console.log("WebSocket disconnected");
+      setWs(null);
+    };
+  };
+
+  useEffect(() => {
+    let heartbeatInterval;
+    if (meeting) {
+      heartbeatInterval = setInterval(async () => {
+        try {
+          await axios.post(`${API}/meetings/${meeting.id}/heartbeat`, {
+            meeting_id: meeting.id,
+            organizer_name: meeting.organizer_name,
+          });
+          setLastHeartbeat(Date.now());
+        } catch (error) {
+          console.error("Erreur lors de l'envoi du heartbeat:", error);
+        }
+      }, 60000);
+    }
+    return () => {
+      if (heartbeatInterval) {
+        clearInterval(heartbeatInterval);
+      }
+    };
+  }, [meeting]);
+
+  return (
+    <MeetingContext.Provider
+      value={{
+        meeting,
+        setMeeting,
+        participant,
+        setParticipant,
+        ws,
+        connectWebSocket,
+        meetingClosed,
+        setMeetingClosed,
+        lastHeartbeat,
+      }}
+    >
+      {children}
+    </MeetingContext.Provider>
+  );
+};
+
+export const useMeeting = () => useContext(MeetingContext);
+

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,10 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
+import { MeetingProvider } from "./MeetingContext";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <App />
+    <MeetingProvider>
+      <App />
+    </MeetingProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- add MeetingContext to manage meeting state, websocket, and heartbeat
- wrap app with MeetingProvider
- consume meeting state via `useMeeting` in App

## Testing
- `npm test` (fails: No tests found)
- `npm run lint` (fails: too many warnings)


------
https://chatgpt.com/codex/tasks/task_e_6899aa9320888330bf432f1d57307203